### PR TITLE
Remove example tag from poetry install

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache-primes.outputs.cache-hit != 'true' # Only run if the cache is old
-        run: poetry install --no-interaction -E examples
+        run: poetry install --no-interaction
 
       - name: Lint
         run: poetry run invoke lint


### PR DESCRIPTION
Removing example tag from poetry install to make this call generic, now that pyreal is removing this requirement